### PR TITLE
[API-1629]: Add per-environment config

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,16 @@
 [![Version](https://img.shields.io/npm/v/@vertexvis/vertex-cli.svg)](https://www.npmjs.com/package/@vertexvis/vertex-cli)
 [![License](https://img.shields.io/npm/l/@vertexvis/vertex-cli.svg)](https://github.com/Vertexvis/vertex-cli/blob/master/LICENSE)
 
-The Vertex command-line interface (CLI) allows you to perform operations with a single command instead of making multiple API calls. The CLI uses [`vertex-api-client`](https://github.com/vertexvis/vertex-api-client-ts) to make API calls. It requires the following exported environment variables to create OAuth tokens.
+The Vertex command-line interface (CLI) makes Vertex API calls on your behalf, simplifying common operations into single commands.
+
+To get started with the CLI, [check out our guide](https://developer.vertexvis.com/docs/guides/import-data). Below, find installation and configuration instructions along with a full list of commands and their options. 
+
+Install the CLI with either `npm install -g @vertexvis/vertex-cli` or `yarn global add @vertexvis/vertex-cli`. Then, run `vertex configure` with the optional `--basePath` option to configure your Vertex client ID and secret. The command creates `~/.config/@vertexvis/vertex-cli/config.json` on macOs/Linux and `%LOCALAPPDATA%\@vertexvis/vertex-cli/config.json` on Windows with your credentials. Alternatively, you can override this file with the following environment variables. 
 
 ```shell
 export VERTEX_CLIENT_ID={CLIENT_ID}
 export VERTEX_CLIENT_SECRET={CLIENT_SECRET}
 ```
-
-Below is a full list of commands and their options. To get started with the CLI, [check out our guide](https://developer.vertexvis.com/docs/guides/cli-quick-start).
 
 <!-- toc -->
 * [Vertex CLI](#vertex-cli)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $ npm install -g @vertexvis/vertex-cli
 $ vertex COMMAND
 running command...
 $ vertex (-v|--version|version)
-@vertexvis/vertex-cli/0.5.3 darwin-x64 node-v14.16.0
+@vertexvis/vertex-cli/0.6.0 darwin-x64 node-v14.16.0
 $ vertex --help [COMMAND]
 USAGE
   $ vertex COMMAND
@@ -39,6 +39,7 @@ USAGE
 # Commands
 
 <!-- commands -->
+* [`vertex configure`](#vertex-configure)
 * [`vertex create-items [PATH]`](#vertex-create-items-path)
 * [`vertex create-parts [PATH]`](#vertex-create-parts-path)
 * [`vertex create-scene [PATH]`](#vertex-create-scene-path)
@@ -46,6 +47,26 @@ USAGE
 * [`vertex delete [ID]`](#vertex-delete-id)
 * [`vertex help [COMMAND]`](#vertex-help-command)
 * [`vertex render-image [ID]`](#vertex-render-image-id)
+
+## `vertex configure`
+
+Configure Vertex credentials.
+
+```
+USAGE
+  $ vertex configure
+
+OPTIONS
+  -b, --basePath=basePath  [default: https://platform.vertexvis.com] Vertex API base path.
+  -h, --help               show CLI help
+  -v, --verbose
+
+EXAMPLE
+  $ vertex configure
+  Saved 'https://platform.vertexvis.com' configuration to '~/.config/@vertexvis/vertex-cli/config.json'.
+```
+
+_See code: [src/commands/configure.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.6.0/src/commands/configure.ts)_
 
 ## `vertex create-items [PATH]`
 
@@ -74,7 +95,7 @@ EXAMPLE
   Wrote 5 pvs item(s) from 'path/to/file' to 'items.json'.
 ```
 
-_See code: [src/commands/create-items.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.5.3/src/commands/create-items.ts)_
+_See code: [src/commands/create-items.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.6.0/src/commands/create-items.ts)_
 
 ## `vertex create-parts [PATH]`
 
@@ -97,7 +118,7 @@ EXAMPLE
   Uploading file(s) and creating part(s)... done
 ```
 
-_See code: [src/commands/create-parts.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.5.3/src/commands/create-parts.ts)_
+_See code: [src/commands/create-parts.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.6.0/src/commands/create-parts.ts)_
 
 ## `vertex create-scene [PATH]`
 
@@ -119,7 +140,7 @@ EXAMPLE
   Created scene f79d4760-0b71-44e4-ad0b-22743fdd4ca3.
 ```
 
-_See code: [src/commands/create-scene.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.5.3/src/commands/create-scene.ts)_
+_See code: [src/commands/create-scene.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.6.0/src/commands/create-scene.ts)_
 
 ## `vertex create-stream-key [ID]`
 
@@ -140,7 +161,7 @@ EXAMPLE
   Created stream-key 'hBXAoQdnsHVhgDZkxeLEPQVxPJ600QwDMdgq' expiring in 600 seconds.
 ```
 
-_See code: [src/commands/create-stream-key.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.5.3/src/commands/create-stream-key.ts)_
+_See code: [src/commands/create-stream-key.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.6.0/src/commands/create-stream-key.ts)_
 
 ## `vertex delete [ID]`
 
@@ -162,7 +183,7 @@ EXAMPLE
   Delete scene(s) f79d4760-0b71-44e4-ad0b-22743fdd4ca3.
 ```
 
-_See code: [src/commands/delete.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.5.3/src/commands/delete.ts)_
+_See code: [src/commands/delete.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.6.0/src/commands/delete.ts)_
 
 ## `vertex help [COMMAND]`
 
@@ -204,5 +225,5 @@ EXAMPLE
   Image written to 'f79d4760-0b71-44e4-ad0b-22743fdd4ca3.jpg'.
 ```
 
-_See code: [src/commands/render-image.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.5.3/src/commands/render-image.ts)_
+_See code: [src/commands/render-image.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.6.0/src/commands/render-image.ts)_
 <!-- commandsstop -->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertexvis/vertex-cli",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "The Vertex platform command-line interface (CLI).",
   "license": "MIT",
   "author": "Vertex Developers <support@vertexvis.com> (https://developer.vertexvis.com)",

--- a/package.json
+++ b/package.json
@@ -25,14 +25,16 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^3",
-    "@vertexvis/vertex-api-client": "^0.8",
+    "@vertexvis/vertex-api-client": "^0.9",
     "cli-ux": "^5.5",
     "fast-xml-parser": "^3.18",
+    "fs-extra": "^9.1",
     "nanoid": "^3.1",
     "tslib": "^2"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1",
+    "@types/fs-extra": "^9.0",
     "@types/node": "^14.14",
     "@vertexvis/eslint-config-vertexvis-typescript": "0.4",
     "eslint": "^7",

--- a/src/commands/configure.ts
+++ b/src/commands/configure.ts
@@ -1,0 +1,55 @@
+import cli from 'cli-ux';
+import { mkdirp, readJSON, writeFile } from 'fs-extra';
+import { join } from 'path';
+import BaseCommand, { FileConfig } from '../base';
+
+export default class Configure extends BaseCommand {
+  public static description = `Configure Vertex credentials.`;
+
+  public static examples = [
+    `$ vertex configure
+Saved 'https://platform.vertexvis.com' configuration to '~/.config/@vertexvis/vertex-cli/config.json'.
+`,
+  ];
+
+  public static flags = { ...BaseCommand.flags };
+
+  public async run(): Promise<void> {
+    const {
+      flags: { basePath },
+    } = this.parse(Configure);
+    const client = this.userConfig?.client;
+    const id = await cli.prompt(`Vertex client ID`, {
+      default: client?.id,
+      required: false,
+    });
+    const secret = await cli.prompt(`Vertex client secret`, {
+      default: client?.secret,
+      required: false,
+      type: 'hide',
+    });
+
+    const configPath = join(this.config.configDir, 'config.json');
+    await mkdirp(this.config.configDir);
+    await writeFile(
+      configPath,
+      JSON.stringify(await this.buildConfig(basePath, configPath, id, secret))
+    );
+    this.log(`Saved '${basePath}' configuration to '${configPath}'.`);
+  }
+
+  private async buildConfig(
+    basePath: string,
+    configPath: string,
+    id: string,
+    secret: string
+  ): Promise<FileConfig> {
+    try {
+      const fileConfig: FileConfig = await readJSON(configPath);
+      fileConfig[basePath] = { client: { id, secret } };
+      return fileConfig;
+    } catch {
+      return { [basePath]: { client: { id, secret } } };
+    }
+  }
+}

--- a/src/commands/create-parts.ts
+++ b/src/commands/create-parts.ts
@@ -67,6 +67,7 @@ Uploading file(s) and creating part(s)... done
     const client = await VertexClient.build({
       axiosOptions: { httpsAgent: new Agent({ keepAlive: true }) },
       basePath,
+      client: this.userConfig?.client,
     });
 
     const itemsWithGeometry = new Map<string, Args>();

--- a/src/commands/create-scene.ts
+++ b/src/commands/create-scene.ts
@@ -52,6 +52,7 @@ Created scene f79d4760-0b71-44e4-ad0b-22743fdd4ca3.
       const client = await VertexClient.build({
         axiosOptions: { httpsAgent: new Agent({ keepAlive: true }) },
         basePath,
+        client: this.userConfig?.client,
       });
       const items: SceneItem[] = JSON.parse(readFileSync(path, Utf8));
       items.sort((a, b) => (a.depth || 0) - (b.depth || 0));

--- a/src/commands/create-stream-key.ts
+++ b/src/commands/create-stream-key.ts
@@ -32,7 +32,10 @@ Created stream-key 'hBXAoQdnsHVhgDZkxeLEPQVxPJ600QwDMdgq' expiring in 600 second
     }
 
     try {
-      const client = await VertexClient.build({ basePath });
+      const client = await VertexClient.build({
+        basePath,
+        client: this.userConfig?.client,
+      });
       const streamKeyRes = await client.streamKeys.createSceneStreamKey({
         id,
         createStreamKeyRequest: {

--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -65,6 +65,7 @@ Delete scene(s) f79d4760-0b71-44e4-ad0b-22743fdd4ca3.
         client: await VertexClient.build({
           axiosOptions: { httpsAgent: new Agent({ keepAlive: true }) },
           basePath,
+          client: this.userConfig?.client,
         }),
         resource: resource,
         verbose: verbose,

--- a/src/commands/render-image.ts
+++ b/src/commands/render-image.ts
@@ -61,7 +61,10 @@ Image written to 'f79d4760-0b71-44e4-ad0b-22743fdd4ca3.jpg'.
       this.error(`--viewer flag only allowed for scene resources.`);
 
     try {
-      const client = await VertexClient.build({ basePath });
+      const client = await VertexClient.build({
+        basePath,
+        client: this.userConfig?.client,
+      });
       if (viewer) {
         const streamKeyRes = await client.streamKeys.createSceneStreamKey({
           id: id,
@@ -148,13 +151,28 @@ function generateHtml(
     ? `platstaging`
     : undefined;
 
-  return `<html>
+  return `<!DOCTYPE html>
+<html lang="">
   <head>
     <meta charset="utf-8" />
+    <title>Getting Started with Vertex</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link
       rel="stylesheet"
       href="https://unpkg.com/@vertexvis/viewer@0.9.x/dist/viewer/viewer.css"
     />
+    <style>
+      html,
+      body,
+      .viewer {
+        width: 100%;
+        height: 100%;
+        padding: 0;
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
     <script
       type="module"
       src="https://unpkg.com/@vertexvis/viewer@0.9.x/dist/viewer/viewer.esm.js"
@@ -163,50 +181,49 @@ function generateHtml(
       nomodule
       src="https://unpkg.com/@vertexvis/viewer@0.9.x/dist/viewer.js"
     ></script>
-  </head>
-  <body>
-    <vertex-viewer id="viewer" class="viewer" client-id="${
-      clientId || `[CLIENT_ID]`
-    }" style="width: auto; height: auto">
+
+    <vertex-viewer
+      class="viewer"
+      client-id="${clientId || `[CLIENT_ID]`}"
+    >
     </vertex-viewer>
 
     <script type="module">
-      import { ColorMaterial } from 'https://unpkg.com/@vertexvis/viewer@0.9.x/dist/esm/index.mjs';
-      import { defineCustomElements } from 'https://unpkg.com/@vertexvis/viewer@0.9.x/dist/esm/loader.mjs';
-
-      document.addEventListener('DOMContentLoaded', () => {
-        main();
-      });
+      import { defineCustomElements } from 'https://unpkg.com/@vertexvis/viewer@0.9.x/dist/esm/loader.js';
+      import { ColorMaterial } from 'https://unpkg.com/@vertexvis/viewer@0.9.x/dist/esm/index.js';
 
       async function main() {
-        await defineCustomElements();
+        await defineCustomElements(window);
+
         const viewer = document.querySelector('vertex-viewer');
         ${config ? `viewer.configEnv = '${config}';` : ''}
         await viewer.load('urn:vertexvis:stream-key:${streamKey}');
 
+        const scene = await viewer.scene();
+        const raycaster = scene.raycaster();
+
         viewer.addEventListener('tap', async (event) => {
-          const { position } = event.detail;
-          const scene = await viewer.scene();
-          const raycaster = await scene.raycaster();
+          const result = await raycaster.hitItems(event.detail.position);
+          const [hit] = result.hits;
 
-          const result = await raycaster.hitItems(position);
-
-          if (result.hits && result.hits.length == 0) {
+          if (hit != null) {
             await scene
-              .items((op) => op.where((q) => q.all()).clearMaterialOverrides())
+              .items((op) => [
+                op.where((q) => q.all()).deselect(),
+                op
+                  .where((q) => q.withItemId(hit.itemId.hex))
+                  .select(ColorMaterial.fromHex('#ff0000')),
+              ])
               .execute();
           } else {
             await scene
-              .items((op) => [
-                op.where((q) => q.all()).clearMaterialOverrides(),
-                op
-                  .where((q) => q.withItemId(result.hits[0].itemId.hex))
-                  .materialOverride(ColorMaterial.fromHex('#ff0000')),
-              ])
+              .items((op) => op.where((q) => q.all()).deselect())
               .execute();
           }
         });
       }
+
+      main();
     </script>
   </body>
 </html>`;

--- a/src/commands/render-image.ts
+++ b/src/commands/render-image.ts
@@ -80,7 +80,7 @@ Image written to 'f79d4760-0b71-44e4-ad0b-22743fdd4ca3.jpg'.
         if (!key) this.error('Error creating stream-key');
         writeFileSync(
           out,
-          generateHtml(key, basePath, process.env.VERTEX_CLIENT_ID)
+          generateHtml(key, basePath, this.userConfig?.client?.id)
         );
 
         this.log(`Viewer HTML written to '${out}'.`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -162,6 +162,13 @@
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
   integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
 
+"@types/fs-extra@^9.0":
+  version "9.0.8"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.8.tgz#32c3c07ddf8caa5020f84b5f65a48470519f78ba"
+  integrity sha512-bnlTVTwq03Na7DpWxFJ1dvnORob+Otb8xHyUqUWhqvz/Ksg8+JXPlR52oeMSZ37YEOa5PyccbgUNutiQdi13TA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/glob@^7.1.1":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.3.tgz#e6ba80f36b7daad2c685acd9266382e68985c183"
@@ -323,10 +330,10 @@
     eslint-plugin-prettier "^3.3.1"
     prettier "^2.2.1"
 
-"@vertexvis/vertex-api-client@^0.8":
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/@vertexvis/vertex-api-client/-/vertex-api-client-0.8.2.tgz#9be4a390e903415f259b9a4fa6fa246c41f9bc0f"
-  integrity sha512-ANSzjOq/AU7I+ZyvC6ePkQ4rAdMe855IRiDQYlPTWFKoVe725nnIwf9ZzXp1LW6cJj+bUxImSc1+MEfmJIbzRw==
+"@vertexvis/vertex-api-client@^0.9":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@vertexvis/vertex-api-client/-/vertex-api-client-0.9.0.tgz#f5aae08220fcd67bac639873f9e5cfb3bb89a206"
+  integrity sha512-LmBcvuni7imD5pftwbIoULS7BaO3YKA2jJwAu/8cSNfYmMRqZ1uvck8nqsg77Ge50J6GnqGIvs+ow9uIT/u0dw==
   dependencies:
     axios "^0.21"
     p-limit "^3.1"
@@ -436,6 +443,11 @@ astral-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
+
+at-least-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
+  integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
 axios@^0.21:
   version "0.21.1"
@@ -1134,6 +1146,16 @@ fs-extra@^8.1:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs-extra@^9.1:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
+  integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
+  dependencies:
+    at-least-node "^1.0.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -1465,6 +1487,15 @@ jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
   integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
+jsonfile@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
+  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
+  dependencies:
+    universalify "^2.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
 
@@ -2386,6 +2417,11 @@ universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
+
+universalify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
+  integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
 uri-js@^4.2.2:
   version "4.4.1"


### PR DESCRIPTION
This allows you to set credentials for multiple environments. Run `vertex configure -b [BASE_PATH]` for each environment. Follow-on commands will then work in any environment without having to swap environment variables.

If you have `VERTEX_CLIENT_ID` and `VERTEX_CLIENT_SECRET` exported, however, they will take precedence.