### PR TITLE
Use srcPath instead of path in create-parts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertexvis/cli",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "The Vertex platform command-line interface (CLI).",
   "license": "MIT",
   "author": "Vertex Developers <support@vertexvis.com> (https://developer.vertexvis.com)",

--- a/src/commands/create-parts.ts
+++ b/src/commands/create-parts.ts
@@ -87,7 +87,7 @@ export default class CreateParts extends BaseCommand {
               verbose,
               fileName,
               indexMetadata: i.indexMetadata ?? false,
-              path,
+              path: srcPath,
               suppliedInstanceIdKey: i.suppliedInstanceIdKey,
               suppliedPartId: i.source?.suppliedPartId,
               suppliedRevisionId: i.source?.suppliedRevisionId,


### PR DESCRIPTION
## Summary
The create-parts command was using the wrong path for the target file.