### PR TITLE
[PLAT-1964] Resolves issue with full path as filename

### DIFF
--- a/src/commands/create-parts.ts
+++ b/src/commands/create-parts.ts
@@ -11,7 +11,7 @@ import cli from 'cli-ux';
 import { readFileSync } from 'fs';
 import { readFile } from 'fs-extra';
 import pLimit from 'p-limit';
-import { join, basename } from 'path';
+import { basename, join } from 'path';
 
 import { SceneItem } from '../create-items/index.d';
 import BaseCommand from '../lib/base';

--- a/src/commands/create-parts.ts
+++ b/src/commands/create-parts.ts
@@ -11,7 +11,7 @@ import cli from 'cli-ux';
 import { readFileSync } from 'fs';
 import { readFile } from 'fs-extra';
 import pLimit from 'p-limit';
-import { join } from 'path';
+import { join, basename } from 'path';
 
 import { SceneItem } from '../create-items/index.d';
 import BaseCommand from '../lib/base';
@@ -147,7 +147,7 @@ function createPart({
     client,
     createFileReq: {
       data: {
-        attributes: { name: fileName, suppliedId: fileName },
+        attributes: { name: basename(fileName), suppliedId: fileName },
         type: 'file',
       },
     },


### PR DESCRIPTION
## Summary
When a full Windows file path is specified for the `filename` field in the JSON file which gets passed into a `create-parts` call, the file fails to translate successfully. This is due to a full path being supplied as the filename within the API call which creates the File.

This improvement ensures that only the base filename is provided to the Create File API.

## Test Plan
Reproduce issue by creating a JSON file for use with `create-parts` which includes a full windows path in the filename field. Ex. `C:\\TEST DATA\CLI\MODELS\part_123.ol`

## Release Notes
Fixed an issue where full paths specified the `create-parts` JSON file could result in failed translations.

## Possible Regressions
Should only impact `create-parts`.

## Dependencies
None
