### PR TITLE
[PLAT-2038] Improved experimental scene creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ npm install -g @vertexvis/cli
 $ vertex COMMAND
 running command...
 $ vertex (-v|--version|version)
-@vertexvis/cli/0.16.2 darwin-x64 node-v16.16.0
+@vertexvis/cli/0.16.3 darwin-x64 node-v16.7.0
 $ vertex --help [COMMAND]
 USAGE
   $ vertex COMMAND
@@ -99,7 +99,7 @@ EXAMPLE
   Saved 'https://platform.vertexvis.com' configuration to '~/.config/@vertexvis/cli/config.json'.
 ```
 
-_See code: [src/commands/configure.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.2/src/commands/configure.ts)_
+_See code: [src/commands/configure.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.3/src/commands/configure.ts)_
 
 ## `vertex create-items [PATH]`
 
@@ -128,7 +128,7 @@ EXAMPLE
   Wrote 5 pvs item(s) from '[YOUR_PATH_TO_XML_FILE]' to 'items.json'.
 ```
 
-_See code: [src/commands/create-items.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.2/src/commands/create-items.ts)_
+_See code: [src/commands/create-items.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.3/src/commands/create-items.ts)_
 
 ## `vertex create-parts [PATH]`
 
@@ -150,7 +150,7 @@ EXAMPLE
     ████████████████████████████████████████ 100% | 10/10
 ```
 
-_See code: [src/commands/create-parts.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.2/src/commands/create-parts.ts)_
+_See code: [src/commands/create-parts.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.3/src/commands/create-parts.ts)_
 
 ## `vertex create-scene [PATH]`
 
@@ -177,7 +177,7 @@ EXAMPLE
   f79d4760-0b71-44e4-ad0b-22743fdd4ca3
 ```
 
-_See code: [src/commands/create-scene.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.2/src/commands/create-scene.ts)_
+_See code: [src/commands/create-scene.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.3/src/commands/create-scene.ts)_
 
 ## `vertex exports:create`
 
@@ -199,7 +199,7 @@ EXAMPLE
   bf0c4343-96eb-4aa9-8dee-e79c6458dedf
 ```
 
-_See code: [src/commands/exports/create.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.2/src/commands/exports/create.ts)_
+_See code: [src/commands/exports/create.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.3/src/commands/exports/create.ts)_
 
 ## `vertex exports:download ID`
 
@@ -220,7 +220,7 @@ EXAMPLE
   Export saved as: 54964c61-05d8-4f37-9638-18f7c4960c80
 ```
 
-_See code: [src/commands/exports/download.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.2/src/commands/exports/download.ts)_
+_See code: [src/commands/exports/download.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.3/src/commands/exports/download.ts)_
 
 ## `vertex exports:get ID`
 
@@ -242,7 +242,7 @@ EXAMPLE
   54964c61-05d8-4f37-9638-18f7c4960c80 https://some-url.com/some-file
 ```
 
-_See code: [src/commands/exports/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.2/src/commands/exports/get.ts)_
+_See code: [src/commands/exports/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.3/src/commands/exports/get.ts)_
 
 ## `vertex files:delete [ID]`
 
@@ -264,7 +264,7 @@ EXAMPLE
   Deleting file(s)...... done
 ```
 
-_See code: [src/commands/files/delete.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.2/src/commands/files/delete.ts)_
+_See code: [src/commands/files/delete.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.3/src/commands/files/delete.ts)_
 
 ## `vertex files:get ID`
 
@@ -286,7 +286,7 @@ EXAMPLE
   54964c61-05d8-4f37-9638-18f7c4960c80 my-file
 ```
 
-_See code: [src/commands/files/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.2/src/commands/files/get.ts)_
+_See code: [src/commands/files/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.3/src/commands/files/get.ts)_
 
 ## `vertex files:list`
 
@@ -310,7 +310,7 @@ EXAMPLE
   a8070713-e48e-466b-b4bb-b3132895d5ce my-file-2
 ```
 
-_See code: [src/commands/files/list.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.2/src/commands/files/list.ts)_
+_See code: [src/commands/files/list.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.3/src/commands/files/list.ts)_
 
 ## `vertex help [COMMAND]`
 
@@ -327,7 +327,7 @@ OPTIONS
   --all  see all commands in CLI
 ```
 
-_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v3.2.18/src/commands/help.ts)_
+_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v3.3.1/src/commands/help.ts)_
 
 ## `vertex part-revisions:render ID`
 
@@ -350,7 +350,7 @@ EXAMPLE
   54964c61-05d8-4f37-9638-18f7c4960c80.jpg
 ```
 
-_See code: [src/commands/part-revisions/render.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.2/src/commands/part-revisions/render.ts)_
+_See code: [src/commands/part-revisions/render.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.3/src/commands/part-revisions/render.ts)_
 
 ## `vertex parts:delete [ID]`
 
@@ -372,7 +372,7 @@ EXAMPLE
   Deleting part(s)...... done
 ```
 
-_See code: [src/commands/parts/delete.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.2/src/commands/parts/delete.ts)_
+_See code: [src/commands/parts/delete.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.3/src/commands/parts/delete.ts)_
 
 ## `vertex parts:get ID`
 
@@ -394,7 +394,7 @@ EXAMPLE
   54964c61-05d8-4f37-9638-18f7c4960c80 my-part
 ```
 
-_See code: [src/commands/parts/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.2/src/commands/parts/get.ts)_
+_See code: [src/commands/parts/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.3/src/commands/parts/get.ts)_
 
 ## `vertex parts:list`
 
@@ -418,7 +418,7 @@ EXAMPLE
   a8070713-e48e-466b-b4bb-b3132895d5ce my-part-2
 ```
 
-_See code: [src/commands/parts/list.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.2/src/commands/parts/list.ts)_
+_See code: [src/commands/parts/list.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.3/src/commands/parts/list.ts)_
 
 ## `vertex scene-items:get ID`
 
@@ -440,7 +440,7 @@ EXAMPLE
   54964c61-05d8-4f37-9638-18f7c4960c80 my-scene-item
 ```
 
-_See code: [src/commands/scene-items/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.2/src/commands/scene-items/get.ts)_
+_See code: [src/commands/scene-items/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.3/src/commands/scene-items/get.ts)_
 
 ## `vertex scene-items:list`
 
@@ -465,7 +465,7 @@ EXAMPLE
   a8070713-e48e-466b-b4bb-b3132895d5ce my-scene-item-2
 ```
 
-_See code: [src/commands/scene-items/list.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.2/src/commands/scene-items/list.ts)_
+_See code: [src/commands/scene-items/list.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.3/src/commands/scene-items/list.ts)_
 
 ## `vertex scene-view-states:delete [ID]`
 
@@ -487,7 +487,7 @@ EXAMPLE
   Deleting scene view state(s)...... done
 ```
 
-_See code: [src/commands/scene-view-states/delete.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.2/src/commands/scene-view-states/delete.ts)_
+_See code: [src/commands/scene-view-states/delete.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.3/src/commands/scene-view-states/delete.ts)_
 
 ## `vertex scene-view-states:get ID`
 
@@ -509,7 +509,7 @@ EXAMPLE
   54964c61-05d8-4f37-9638-18f7c4960c80 my-scene-view-state
 ```
 
-_See code: [src/commands/scene-view-states/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.2/src/commands/scene-view-states/get.ts)_
+_See code: [src/commands/scene-view-states/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.3/src/commands/scene-view-states/get.ts)_
 
 ## `vertex scene-view-states:list`
 
@@ -534,7 +534,7 @@ EXAMPLE
   a8070713-e48e-466b-b4bb-b3132895d5ce my-scene-view-state-2
 ```
 
-_See code: [src/commands/scene-view-states/list.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.2/src/commands/scene-view-states/list.ts)_
+_See code: [src/commands/scene-view-states/list.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.3/src/commands/scene-view-states/list.ts)_
 
 ## `vertex scene-views:create`
 
@@ -555,7 +555,7 @@ EXAMPLE
   bf0c4343-96eb-4aa9-8dee-e79c6458dedf
 ```
 
-_See code: [src/commands/scene-views/create.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.2/src/commands/scene-views/create.ts)_
+_See code: [src/commands/scene-views/create.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.3/src/commands/scene-views/create.ts)_
 
 ## `vertex scene-views:get ID`
 
@@ -577,7 +577,7 @@ EXAMPLE
   54964c61-05d8-4f37-9638-18f7c4960c80 my-scene-view
 ```
 
-_See code: [src/commands/scene-views/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.2/src/commands/scene-views/get.ts)_
+_See code: [src/commands/scene-views/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.3/src/commands/scene-views/get.ts)_
 
 ## `vertex scene-views:list`
 
@@ -602,7 +602,7 @@ EXAMPLE
   a8070713-e48e-466b-b4bb-b3132895d5ce my-scene-view-2
 ```
 
-_See code: [src/commands/scene-views/list.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.2/src/commands/scene-views/list.ts)_
+_See code: [src/commands/scene-views/list.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.3/src/commands/scene-views/list.ts)_
 
 ## `vertex scene-views:render ID`
 
@@ -625,7 +625,7 @@ EXAMPLE
   54964c61-05d8-4f37-9638-18f7c4960c80.jpg
 ```
 
-_See code: [src/commands/scene-views/render.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.2/src/commands/scene-views/render.ts)_
+_See code: [src/commands/scene-views/render.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.3/src/commands/scene-views/render.ts)_
 
 ## `vertex scenes:delete [ID]`
 
@@ -647,7 +647,7 @@ EXAMPLE
   Deleting scene(s)...... done
 ```
 
-_See code: [src/commands/scenes/delete.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.2/src/commands/scenes/delete.ts)_
+_See code: [src/commands/scenes/delete.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.3/src/commands/scenes/delete.ts)_
 
 ## `vertex scenes:get ID`
 
@@ -669,7 +669,7 @@ EXAMPLE
   54964c61-05d8-4f37-9638-18f7c4960c80 my-scene
 ```
 
-_See code: [src/commands/scenes/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.2/src/commands/scenes/get.ts)_
+_See code: [src/commands/scenes/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.3/src/commands/scenes/get.ts)_
 
 ## `vertex scenes:list`
 
@@ -693,7 +693,7 @@ EXAMPLE
   a8070713-e48e-466b-b4bb-b3132895d5ce my-scene-2
 ```
 
-_See code: [src/commands/scenes/list.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.2/src/commands/scenes/list.ts)_
+_See code: [src/commands/scenes/list.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.3/src/commands/scenes/list.ts)_
 
 ## `vertex scenes:render ID`
 
@@ -717,7 +717,7 @@ EXAMPLE
   54964c61-05d8-4f37-9638-18f7c4960c80.jpg
 ```
 
-_See code: [src/commands/scenes/render.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.2/src/commands/scenes/render.ts)_
+_See code: [src/commands/scenes/render.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.3/src/commands/scenes/render.ts)_
 
 ## `vertex stream-keys:create`
 
@@ -739,7 +739,7 @@ EXAMPLE
   hBXAoQdnsHVhgDZkxeLEPQVxPJ600QwDMdgq
 ```
 
-_See code: [src/commands/stream-keys/create.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.2/src/commands/stream-keys/create.ts)_
+_See code: [src/commands/stream-keys/create.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.3/src/commands/stream-keys/create.ts)_
 
 ## `vertex webhook-subscriptions:create`
 
@@ -761,5 +761,5 @@ EXAMPLE
   ta47eOIQtg13pSyf/PgpAB47r4JYJoAZfyzAcB5x8IHo+gQ
 ```
 
-_See code: [src/commands/webhook-subscriptions/create.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.2/src/commands/webhook-subscriptions/create.ts)_
+_See code: [src/commands/webhook-subscriptions/create.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.3/src/commands/webhook-subscriptions/create.ts)_
 <!-- commandsstop -->

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "bugs": {
     "url": "https://github.com/Vertexvis/vertex-cli/issues"
   },
-  "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "publishConfig": {
     "registry": "https://registry.npmjs.org",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/Vertexvis/vertex-cli/issues"
   },
+  "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "publishConfig": {
     "registry": "https://registry.npmjs.org",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertexvis/cli",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "The Vertex platform command-line interface (CLI).",
   "license": "MIT",
   "author": "Vertex Developers <support@vertexvis.com> (https://developer.vertexvis.com)",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1.18.2",
     "@oclif/plugin-help": "^3.3.1",
-    "@vertexvis/api-client-node": "0.20.3",
+    "@vertexvis/api-client-node": "^0.20.3",
     "cli-ux": "^5.6.7",
     "fast-xml-parser": "^3.21",
     "fs-extra": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1.18.2",
     "@oclif/plugin-help": "^3.3.1",
-    "@vertexvis/api-client-node": "^0.20.0",
+    "@vertexvis/api-client-node": "0.20.3",
     "cli-ux": "^5.6.7",
     "fast-xml-parser": "^3.21",
     "fs-extra": "^10.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -636,7 +636,7 @@
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
 
-"@vertexvis/api-client-node@0.20.3":
+"@vertexvis/api-client-node@^0.20.3":
   version "0.20.3"
   resolved "https://registry.yarnpkg.com/@vertexvis/api-client-node/-/api-client-node-0.20.3.tgz#529bce96ff8a64ac86356ab5efc382325ec3e8f3"
   integrity sha512-h+eVGFgo6+WHNQ/0pauIoulkRUFW/LO/uIIv3RRtU5zvdp0wTB4zdXBS/LLtjOwEM1fSqymt3fafUOrlQJSopw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -636,10 +636,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
 
-"@vertexvis/api-client-node@^0.20.0":
-  version "0.20.0"
-  resolved "https://registry.yarnpkg.com/@vertexvis/api-client-node/-/api-client-node-0.20.0.tgz#7e222a6e46e1d414876bc2a462522bf4f0298a46"
-  integrity sha512-yYIud4vRMkmTQVLkAztnFkp/mKNpcXJ3RRkJI8XkIrIBmYfPCL7doJagQSg5vOUtiMydM4sNOLXON07a0pixdA==
+"@vertexvis/api-client-node@0.20.3":
+  version "0.20.3"
+  resolved "https://registry.yarnpkg.com/@vertexvis/api-client-node/-/api-client-node-0.20.3.tgz#529bce96ff8a64ac86356ab5efc382325ec3e8f3"
+  integrity sha512-h+eVGFgo6+WHNQ/0pauIoulkRUFW/LO/uIIv3RRtU5zvdp0wTB4zdXBS/LLtjOwEM1fSqymt3fafUOrlQJSopw==
   dependencies:
     axios "^0.27.2"
     p-limit "^3"


### PR DESCRIPTION
## Summary
This change set introduces an improved experimental approach for scene item creation when using `create-scene` with the `--experimental` flag. Scene items will be created in stages based on depth. Run with the `-v` option for more detailed status output.

## Test Plan
Test `create-scene` with and without the `--experimental` and `-v` flags.