### PR TITLE
PLAT-2539: Scene item ordinals, names, placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ npm install -g @vertexvis/cli
 $ vertex COMMAND
 running command...
 $ vertex (-v|--version|version)
-@vertexvis/cli/0.16.5 darwin-x64 node-v16.7.0
+@vertexvis/cli/0.17.0 darwin-x64 node-v19.6.1
 $ vertex --help [COMMAND]
 USAGE
   $ vertex COMMAND
@@ -99,7 +99,7 @@ EXAMPLE
   Saved 'https://platform.vertexvis.com' configuration to '~/.config/@vertexvis/cli/config.json'.
 ```
 
-_See code: [src/commands/configure.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.5/src/commands/configure.ts)_
+_See code: [src/commands/configure.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.0/src/commands/configure.ts)_
 
 ## `vertex create-items [PATH]`
 
@@ -128,7 +128,7 @@ EXAMPLE
   Wrote 5 pvs item(s) from '[YOUR_PATH_TO_XML_FILE]' to 'items.json'.
 ```
 
-_See code: [src/commands/create-items.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.5/src/commands/create-items.ts)_
+_See code: [src/commands/create-items.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.0/src/commands/create-items.ts)_
 
 ## `vertex create-parts [PATH]`
 
@@ -150,7 +150,7 @@ EXAMPLE
     ████████████████████████████████████████ 100% | 10/10
 ```
 
-_See code: [src/commands/create-parts.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.5/src/commands/create-parts.ts)_
+_See code: [src/commands/create-parts.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.0/src/commands/create-parts.ts)_
 
 ## `vertex create-scene [PATH]`
 
@@ -165,11 +165,11 @@ OPTIONS
   -h, --help                     show CLI help
   -p, --parallelism=parallelism  [default: 20] Number of scene-items to create in parallel.
   -v, --verbose
-  --experimental                 Whether or not to use batch scene item creation.
   --name=name                    Name of scene.
-  --noFailFast                   Whether or not to fail if any scene item fails initial validation.
+  --noFailFast                   Whether or not to fail the process immediately if any scene item creation fails.
   --suppliedId=suppliedId        SuppliedId of scene.
-  --treeEnabled                  Whether or not scene trees can be viewed for this scene.
+  --treeEnabled                  Whether or not scene trees should be enabled for this scene.
+  --validate                     Whether or not to validate the creation of every scene item.
 
 EXAMPLE
   $ vertex create-scene --name my-scene [YOUR_PATH_TO_JSON_FILE]
@@ -177,7 +177,7 @@ EXAMPLE
   f79d4760-0b71-44e4-ad0b-22743fdd4ca3
 ```
 
-_See code: [src/commands/create-scene.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.5/src/commands/create-scene.ts)_
+_See code: [src/commands/create-scene.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.0/src/commands/create-scene.ts)_
 
 ## `vertex exports:create`
 
@@ -199,7 +199,7 @@ EXAMPLE
   bf0c4343-96eb-4aa9-8dee-e79c6458dedf
 ```
 
-_See code: [src/commands/exports/create.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.5/src/commands/exports/create.ts)_
+_See code: [src/commands/exports/create.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.0/src/commands/exports/create.ts)_
 
 ## `vertex exports:download ID`
 
@@ -220,7 +220,7 @@ EXAMPLE
   Export saved as: 54964c61-05d8-4f37-9638-18f7c4960c80
 ```
 
-_See code: [src/commands/exports/download.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.5/src/commands/exports/download.ts)_
+_See code: [src/commands/exports/download.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.0/src/commands/exports/download.ts)_
 
 ## `vertex exports:get ID`
 
@@ -242,7 +242,7 @@ EXAMPLE
   54964c61-05d8-4f37-9638-18f7c4960c80 https://some-url.com/some-file
 ```
 
-_See code: [src/commands/exports/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.5/src/commands/exports/get.ts)_
+_See code: [src/commands/exports/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.0/src/commands/exports/get.ts)_
 
 ## `vertex files:delete [ID]`
 
@@ -264,7 +264,7 @@ EXAMPLE
   Deleting file(s)...... done
 ```
 
-_See code: [src/commands/files/delete.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.5/src/commands/files/delete.ts)_
+_See code: [src/commands/files/delete.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.0/src/commands/files/delete.ts)_
 
 ## `vertex files:get ID`
 
@@ -286,7 +286,7 @@ EXAMPLE
   54964c61-05d8-4f37-9638-18f7c4960c80 my-file
 ```
 
-_See code: [src/commands/files/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.5/src/commands/files/get.ts)_
+_See code: [src/commands/files/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.0/src/commands/files/get.ts)_
 
 ## `vertex files:list`
 
@@ -310,7 +310,7 @@ EXAMPLE
   a8070713-e48e-466b-b4bb-b3132895d5ce my-file-2
 ```
 
-_See code: [src/commands/files/list.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.5/src/commands/files/list.ts)_
+_See code: [src/commands/files/list.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.0/src/commands/files/list.ts)_
 
 ## `vertex help [COMMAND]`
 
@@ -350,7 +350,7 @@ EXAMPLE
   54964c61-05d8-4f37-9638-18f7c4960c80.jpg
 ```
 
-_See code: [src/commands/part-revisions/render.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.5/src/commands/part-revisions/render.ts)_
+_See code: [src/commands/part-revisions/render.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.0/src/commands/part-revisions/render.ts)_
 
 ## `vertex parts:delete [ID]`
 
@@ -372,7 +372,7 @@ EXAMPLE
   Deleting part(s)...... done
 ```
 
-_See code: [src/commands/parts/delete.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.5/src/commands/parts/delete.ts)_
+_See code: [src/commands/parts/delete.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.0/src/commands/parts/delete.ts)_
 
 ## `vertex parts:get ID`
 
@@ -394,7 +394,7 @@ EXAMPLE
   54964c61-05d8-4f37-9638-18f7c4960c80 my-part
 ```
 
-_See code: [src/commands/parts/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.5/src/commands/parts/get.ts)_
+_See code: [src/commands/parts/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.0/src/commands/parts/get.ts)_
 
 ## `vertex parts:list`
 
@@ -418,7 +418,7 @@ EXAMPLE
   a8070713-e48e-466b-b4bb-b3132895d5ce my-part-2
 ```
 
-_See code: [src/commands/parts/list.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.5/src/commands/parts/list.ts)_
+_See code: [src/commands/parts/list.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.0/src/commands/parts/list.ts)_
 
 ## `vertex scene-items:get ID`
 
@@ -440,7 +440,7 @@ EXAMPLE
   54964c61-05d8-4f37-9638-18f7c4960c80 my-scene-item
 ```
 
-_See code: [src/commands/scene-items/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.5/src/commands/scene-items/get.ts)_
+_See code: [src/commands/scene-items/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.0/src/commands/scene-items/get.ts)_
 
 ## `vertex scene-items:list`
 
@@ -465,7 +465,7 @@ EXAMPLE
   a8070713-e48e-466b-b4bb-b3132895d5ce my-scene-item-2
 ```
 
-_See code: [src/commands/scene-items/list.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.5/src/commands/scene-items/list.ts)_
+_See code: [src/commands/scene-items/list.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.0/src/commands/scene-items/list.ts)_
 
 ## `vertex scene-view-states:delete [ID]`
 
@@ -487,7 +487,7 @@ EXAMPLE
   Deleting scene view state(s)...... done
 ```
 
-_See code: [src/commands/scene-view-states/delete.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.5/src/commands/scene-view-states/delete.ts)_
+_See code: [src/commands/scene-view-states/delete.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.0/src/commands/scene-view-states/delete.ts)_
 
 ## `vertex scene-view-states:get ID`
 
@@ -509,7 +509,7 @@ EXAMPLE
   54964c61-05d8-4f37-9638-18f7c4960c80 my-scene-view-state
 ```
 
-_See code: [src/commands/scene-view-states/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.5/src/commands/scene-view-states/get.ts)_
+_See code: [src/commands/scene-view-states/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.0/src/commands/scene-view-states/get.ts)_
 
 ## `vertex scene-view-states:list`
 
@@ -534,7 +534,7 @@ EXAMPLE
   a8070713-e48e-466b-b4bb-b3132895d5ce my-scene-view-state-2
 ```
 
-_See code: [src/commands/scene-view-states/list.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.5/src/commands/scene-view-states/list.ts)_
+_See code: [src/commands/scene-view-states/list.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.0/src/commands/scene-view-states/list.ts)_
 
 ## `vertex scene-views:create`
 
@@ -555,7 +555,7 @@ EXAMPLE
   bf0c4343-96eb-4aa9-8dee-e79c6458dedf
 ```
 
-_See code: [src/commands/scene-views/create.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.5/src/commands/scene-views/create.ts)_
+_See code: [src/commands/scene-views/create.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.0/src/commands/scene-views/create.ts)_
 
 ## `vertex scene-views:get ID`
 
@@ -577,7 +577,7 @@ EXAMPLE
   54964c61-05d8-4f37-9638-18f7c4960c80 my-scene-view
 ```
 
-_See code: [src/commands/scene-views/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.5/src/commands/scene-views/get.ts)_
+_See code: [src/commands/scene-views/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.0/src/commands/scene-views/get.ts)_
 
 ## `vertex scene-views:list`
 
@@ -602,7 +602,7 @@ EXAMPLE
   a8070713-e48e-466b-b4bb-b3132895d5ce my-scene-view-2
 ```
 
-_See code: [src/commands/scene-views/list.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.5/src/commands/scene-views/list.ts)_
+_See code: [src/commands/scene-views/list.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.0/src/commands/scene-views/list.ts)_
 
 ## `vertex scene-views:render ID`
 
@@ -625,7 +625,7 @@ EXAMPLE
   54964c61-05d8-4f37-9638-18f7c4960c80.jpg
 ```
 
-_See code: [src/commands/scene-views/render.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.5/src/commands/scene-views/render.ts)_
+_See code: [src/commands/scene-views/render.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.0/src/commands/scene-views/render.ts)_
 
 ## `vertex scenes:delete [ID]`
 
@@ -647,7 +647,7 @@ EXAMPLE
   Deleting scene(s)...... done
 ```
 
-_See code: [src/commands/scenes/delete.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.5/src/commands/scenes/delete.ts)_
+_See code: [src/commands/scenes/delete.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.0/src/commands/scenes/delete.ts)_
 
 ## `vertex scenes:get ID`
 
@@ -669,7 +669,7 @@ EXAMPLE
   54964c61-05d8-4f37-9638-18f7c4960c80 my-scene
 ```
 
-_See code: [src/commands/scenes/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.5/src/commands/scenes/get.ts)_
+_See code: [src/commands/scenes/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.0/src/commands/scenes/get.ts)_
 
 ## `vertex scenes:list`
 
@@ -693,7 +693,7 @@ EXAMPLE
   a8070713-e48e-466b-b4bb-b3132895d5ce my-scene-2
 ```
 
-_See code: [src/commands/scenes/list.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.5/src/commands/scenes/list.ts)_
+_See code: [src/commands/scenes/list.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.0/src/commands/scenes/list.ts)_
 
 ## `vertex scenes:render ID`
 
@@ -717,7 +717,7 @@ EXAMPLE
   54964c61-05d8-4f37-9638-18f7c4960c80.jpg
 ```
 
-_See code: [src/commands/scenes/render.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.5/src/commands/scenes/render.ts)_
+_See code: [src/commands/scenes/render.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.0/src/commands/scenes/render.ts)_
 
 ## `vertex stream-keys:create`
 
@@ -739,7 +739,7 @@ EXAMPLE
   hBXAoQdnsHVhgDZkxeLEPQVxPJ600QwDMdgq
 ```
 
-_See code: [src/commands/stream-keys/create.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.5/src/commands/stream-keys/create.ts)_
+_See code: [src/commands/stream-keys/create.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.0/src/commands/stream-keys/create.ts)_
 
 ## `vertex webhook-subscriptions:create`
 
@@ -761,5 +761,5 @@ EXAMPLE
   ta47eOIQtg13pSyf/PgpAB47r4JYJoAZfyzAcB5x8IHo+gQ
 ```
 
-_See code: [src/commands/webhook-subscriptions/create.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.16.5/src/commands/webhook-subscriptions/create.ts)_
+_See code: [src/commands/webhook-subscriptions/create.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.0/src/commands/webhook-subscriptions/create.ts)_
 <!-- commandsstop -->

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1.18.7",
     "@oclif/plugin-help": "^3.3.1",
-    "@vertexvis/api-client-node": "^0.20.6",
+    "@vertexvis/api-client-node": "^0.20.7",
     "cli-ux": "^5.6.7",
     "fast-xml-parser": "^3.21",
     "fs-extra": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertexvis/cli",
-  "version": "0.16.5",
+  "version": "0.17.0",
   "description": "The Vertex platform command-line interface (CLI).",
   "license": "MIT",
   "author": "Vertex Developers <support@vertexvis.com> (https://developer.vertexvis.com)",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1.18.7",
     "@oclif/plugin-help": "^3.3.1",
-    "@vertexvis/api-client-node": "^0.20.7",
+    "@vertexvis/api-client-node": "^0.21.0",
     "cli-ux": "^5.6.7",
     "fast-xml-parser": "^3.21",
     "fs-extra": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1.18.9",
     "@oclif/plugin-help": "^3.3.1",
-    "@vertexvis/api-client-node": "^0.21.0",
+    "@vertexvis/api-client-node": "^0.21.1",
     "cli-ux": "^5.6.7",
     "fast-xml-parser": "^3.21",
     "fs-extra": "^10.1.0",

--- a/src/commands/create-scene.ts
+++ b/src/commands/create-scene.ts
@@ -127,7 +127,7 @@ f79d4760-0b71-44e4-ad0b-22743fdd4ca3
                 suppliedId: i.suppliedId,
                 transform: i.transform,
                 visible: true,
-                name: i.name ?? i.suppliedId ?? undefined,
+                name: i.name ?? undefined,
                 ordinal: i.ordinal ?? undefined,
               },
               relationships: {},

--- a/src/commands/create-scene.ts
+++ b/src/commands/create-scene.ts
@@ -149,9 +149,13 @@ f79d4760-0b71-44e4-ad0b-22743fdd4ca3
         failFast: !noFailFast,
         onMsg: console.error,
         onProgress: (complete, total) => {
-          if (showProgress) progress.update(complete);
+          if (showProgress) {
+            progress.update(complete);
+          }
           if (complete === total) {
-            if (showProgress) progress.stop();
+            if (showProgress) {
+              progress.stop();
+            }
             cli.action.start(
               'Created scene items. Awaiting scene completion...'
             );
@@ -212,7 +216,9 @@ f79d4760-0b71-44e4-ad0b-22743fdd4ca3
       if (sceneData && sceneData.id) {
         const sceneId = sceneData.id;
         if (validate && !errors) {
-          if (verbose) cli.info(`Validating scene items...`);
+          if (verbose) {
+            cli.info(`Validating scene items...`);
+          }
           let sceneItemCount = 0;
           await iterateSceneItems(client, sceneId, (si: SceneItemData) => {
             if (si.attributes.suppliedId) {

--- a/src/create-items/index.d.ts
+++ b/src/create-items/index.d.ts
@@ -39,6 +39,17 @@ export interface SceneItem {
   readonly materialOverride?: ColorMaterial;
 
   /**
+   * Optional name for item.
+   */
+  readonly name?: string;
+
+  /**
+   * Optional A 0-based index used for defining a consistent ordering amongst
+   * sibling scene items.
+   */
+  readonly ordinal?: number;
+
+  /**
    * Optional hierarchical parent of item.
    */
   readonly parentId?: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -669,10 +669,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
 
-"@vertexvis/api-client-node@^0.21.0":
-  version "0.21.0"
-  resolved "https://registry.yarnpkg.com/@vertexvis/api-client-node/-/api-client-node-0.21.0.tgz#1a8dfee65a361dbfdcfc7bfcf61688a01fc24596"
-  integrity sha512-qYGkeejm2D/h8ZnqOxhJySi7hyKziMnhrJ9qvJ20umS6wkP4V6WxJdHve7KkC4PZr+5Lp2+l+cZFZhwKHvfO3Q==
+"@vertexvis/api-client-node@^0.21.1":
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/@vertexvis/api-client-node/-/api-client-node-0.21.1.tgz#f7613b2c0bf6acf90ae249bcfbd89848e16d84be"
+  integrity sha512-9iiZqrA4smzw8QEJy2BZgIuJAlhrhx8NJD0r4+/OuFU4WeFpucpkxKmg/OrXz/ycytizk6rs1I57VS8P+9HtcA==
   dependencies:
     axios "^0.27.2"
     p-limit "^3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -669,10 +669,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
 
-"@vertexvis/api-client-node@^0.20.6":
-  version "0.20.6"
-  resolved "https://registry.yarnpkg.com/@vertexvis/api-client-node/-/api-client-node-0.20.6.tgz#8bf75f4d0226a33a43f24ae030c979fc121b8155"
-  integrity sha512-5EqwWBcZzHSZyxlOJLM4Q54Ym/qml5HWrmKHbD80DFzMcEgVszvqySiVKuZWBG8kUoTnvs6xy6yS0uuM7JFlxw==
+"@vertexvis/api-client-node@^0.20.7":
+  version "0.20.9"
+  resolved "https://registry.yarnpkg.com/@vertexvis/api-client-node/-/api-client-node-0.20.9.tgz#8c7eedafcf9ac1c1a93d85e59cb508891595c4cb"
+  integrity sha512-8kwpWDzc9+Q2Qm1jfj5Kc/Y+ElCffPahegUVDonLJTtI7i60KIxKyKNR6hFO04daMLJwuB2rhiIDyW/XuafUhw==
   dependencies:
     axios "^0.27.2"
     p-limit "^3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -669,10 +669,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
 
-"@vertexvis/api-client-node@^0.20.7":
-  version "0.20.9"
-  resolved "https://registry.yarnpkg.com/@vertexvis/api-client-node/-/api-client-node-0.20.9.tgz#8c7eedafcf9ac1c1a93d85e59cb508891595c4cb"
-  integrity sha512-8kwpWDzc9+Q2Qm1jfj5Kc/Y+ElCffPahegUVDonLJTtI7i60KIxKyKNR6hFO04daMLJwuB2rhiIDyW/XuafUhw==
+"@vertexvis/api-client-node@^0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@vertexvis/api-client-node/-/api-client-node-0.21.0.tgz#1a8dfee65a361dbfdcfc7bfcf61688a01fc24596"
+  integrity sha512-qYGkeejm2D/h8ZnqOxhJySi7hyKziMnhrJ9qvJ20umS6wkP4V6WxJdHve7KkC4PZr+5Lp2+l+cZFZhwKHvfO3Q==
   dependencies:
     axios "^0.27.2"
     p-limit "^3"


### PR DESCRIPTION
## Summary
* Support for latest version of vertex-api-client-node (v0.21.0)
* Added support for scene item ordinals
* Added support for specifying scene item names
* Removed usage of experimental scene creation method
* Added output for placeholder scene items created

## Test Plan
- Test scene creation with small and large scenes, as well as scenes with missing parts/parents
- Test with ordinal supplied with scene item request data
- Test ability to supply scene item name with request data

## Release Notes
- The `--experimental` option is no longer supported for `create-scene`
- `create-scene` now supports a new `--validate` option which will cause all created scene items to be verified to exist on the server at the end of the scene creation process. This is an expensive operation which should generally be used for troubleshooting only.
