### PR TITLE
PLAT-3350 -- Index metadata by default for create-parts command

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ npm install -g @vertexvis/cli
 $ vertex COMMAND
 running command...
 $ vertex (-v|--version|version)
-@vertexvis/cli/0.17.2 darwin-x64 node-v18.16.0
+@vertexvis/cli/0.18.0 darwin-x64 node-v19.6.1
 $ vertex --help [COMMAND]
 USAGE
   $ vertex COMMAND
@@ -99,7 +99,7 @@ EXAMPLE
   Saved 'https://platform.vertexvis.com' configuration to '~/.config/@vertexvis/cli/config.json'.
 ```
 
-_See code: [src/commands/configure.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.2/src/commands/configure.ts)_
+_See code: [src/commands/configure.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.18.0/src/commands/configure.ts)_
 
 ## `vertex create-items [PATH]`
 
@@ -128,7 +128,7 @@ EXAMPLE
   Wrote 5 pvs item(s) from '[YOUR_PATH_TO_XML_FILE]' to 'items.json'.
 ```
 
-_See code: [src/commands/create-items.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.2/src/commands/create-items.ts)_
+_See code: [src/commands/create-items.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.18.0/src/commands/create-items.ts)_
 
 ## `vertex create-parts [PATH]`
 
@@ -150,7 +150,7 @@ EXAMPLE
     ████████████████████████████████████████ 100% | 10/10
 ```
 
-_See code: [src/commands/create-parts.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.2/src/commands/create-parts.ts)_
+_See code: [src/commands/create-parts.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.18.0/src/commands/create-parts.ts)_
 
 ## `vertex create-scene [PATH]`
 
@@ -177,7 +177,7 @@ EXAMPLE
   f79d4760-0b71-44e4-ad0b-22743fdd4ca3
 ```
 
-_See code: [src/commands/create-scene.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.2/src/commands/create-scene.ts)_
+_See code: [src/commands/create-scene.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.18.0/src/commands/create-scene.ts)_
 
 ## `vertex exports:create`
 
@@ -199,7 +199,7 @@ EXAMPLE
   bf0c4343-96eb-4aa9-8dee-e79c6458dedf
 ```
 
-_See code: [src/commands/exports/create.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.2/src/commands/exports/create.ts)_
+_See code: [src/commands/exports/create.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.18.0/src/commands/exports/create.ts)_
 
 ## `vertex exports:download ID`
 
@@ -220,7 +220,7 @@ EXAMPLE
   Export saved as: 54964c61-05d8-4f37-9638-18f7c4960c80
 ```
 
-_See code: [src/commands/exports/download.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.2/src/commands/exports/download.ts)_
+_See code: [src/commands/exports/download.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.18.0/src/commands/exports/download.ts)_
 
 ## `vertex exports:get ID`
 
@@ -242,7 +242,7 @@ EXAMPLE
   54964c61-05d8-4f37-9638-18f7c4960c80 https://some-url.com/some-file
 ```
 
-_See code: [src/commands/exports/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.2/src/commands/exports/get.ts)_
+_See code: [src/commands/exports/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.18.0/src/commands/exports/get.ts)_
 
 ## `vertex files:delete [ID]`
 
@@ -264,7 +264,7 @@ EXAMPLE
   Deleting file(s)...... done
 ```
 
-_See code: [src/commands/files/delete.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.2/src/commands/files/delete.ts)_
+_See code: [src/commands/files/delete.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.18.0/src/commands/files/delete.ts)_
 
 ## `vertex files:get ID`
 
@@ -286,7 +286,7 @@ EXAMPLE
   54964c61-05d8-4f37-9638-18f7c4960c80 my-file
 ```
 
-_See code: [src/commands/files/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.2/src/commands/files/get.ts)_
+_See code: [src/commands/files/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.18.0/src/commands/files/get.ts)_
 
 ## `vertex files:list`
 
@@ -310,7 +310,7 @@ EXAMPLE
   a8070713-e48e-466b-b4bb-b3132895d5ce my-file-2
 ```
 
-_See code: [src/commands/files/list.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.2/src/commands/files/list.ts)_
+_See code: [src/commands/files/list.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.18.0/src/commands/files/list.ts)_
 
 ## `vertex help [COMMAND]`
 
@@ -350,7 +350,7 @@ EXAMPLE
   54964c61-05d8-4f37-9638-18f7c4960c80.jpg
 ```
 
-_See code: [src/commands/part-revisions/render.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.2/src/commands/part-revisions/render.ts)_
+_See code: [src/commands/part-revisions/render.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.18.0/src/commands/part-revisions/render.ts)_
 
 ## `vertex parts:delete [ID]`
 
@@ -372,7 +372,7 @@ EXAMPLE
   Deleting part(s)...... done
 ```
 
-_See code: [src/commands/parts/delete.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.2/src/commands/parts/delete.ts)_
+_See code: [src/commands/parts/delete.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.18.0/src/commands/parts/delete.ts)_
 
 ## `vertex parts:get ID`
 
@@ -394,7 +394,7 @@ EXAMPLE
   54964c61-05d8-4f37-9638-18f7c4960c80 my-part
 ```
 
-_See code: [src/commands/parts/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.2/src/commands/parts/get.ts)_
+_See code: [src/commands/parts/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.18.0/src/commands/parts/get.ts)_
 
 ## `vertex parts:list`
 
@@ -418,7 +418,7 @@ EXAMPLE
   a8070713-e48e-466b-b4bb-b3132895d5ce my-part-2
 ```
 
-_See code: [src/commands/parts/list.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.2/src/commands/parts/list.ts)_
+_See code: [src/commands/parts/list.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.18.0/src/commands/parts/list.ts)_
 
 ## `vertex scene-items:get ID`
 
@@ -440,7 +440,7 @@ EXAMPLE
   54964c61-05d8-4f37-9638-18f7c4960c80 my-scene-item
 ```
 
-_See code: [src/commands/scene-items/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.2/src/commands/scene-items/get.ts)_
+_See code: [src/commands/scene-items/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.18.0/src/commands/scene-items/get.ts)_
 
 ## `vertex scene-items:list`
 
@@ -465,7 +465,7 @@ EXAMPLE
   a8070713-e48e-466b-b4bb-b3132895d5ce my-scene-item-2
 ```
 
-_See code: [src/commands/scene-items/list.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.2/src/commands/scene-items/list.ts)_
+_See code: [src/commands/scene-items/list.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.18.0/src/commands/scene-items/list.ts)_
 
 ## `vertex scene-view-states:delete [ID]`
 
@@ -487,7 +487,7 @@ EXAMPLE
   Deleting scene view state(s)...... done
 ```
 
-_See code: [src/commands/scene-view-states/delete.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.2/src/commands/scene-view-states/delete.ts)_
+_See code: [src/commands/scene-view-states/delete.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.18.0/src/commands/scene-view-states/delete.ts)_
 
 ## `vertex scene-view-states:get ID`
 
@@ -509,7 +509,7 @@ EXAMPLE
   54964c61-05d8-4f37-9638-18f7c4960c80 my-scene-view-state
 ```
 
-_See code: [src/commands/scene-view-states/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.2/src/commands/scene-view-states/get.ts)_
+_See code: [src/commands/scene-view-states/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.18.0/src/commands/scene-view-states/get.ts)_
 
 ## `vertex scene-view-states:list`
 
@@ -534,7 +534,7 @@ EXAMPLE
   a8070713-e48e-466b-b4bb-b3132895d5ce my-scene-view-state-2
 ```
 
-_See code: [src/commands/scene-view-states/list.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.2/src/commands/scene-view-states/list.ts)_
+_See code: [src/commands/scene-view-states/list.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.18.0/src/commands/scene-view-states/list.ts)_
 
 ## `vertex scene-views:create`
 
@@ -555,7 +555,7 @@ EXAMPLE
   bf0c4343-96eb-4aa9-8dee-e79c6458dedf
 ```
 
-_See code: [src/commands/scene-views/create.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.2/src/commands/scene-views/create.ts)_
+_See code: [src/commands/scene-views/create.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.18.0/src/commands/scene-views/create.ts)_
 
 ## `vertex scene-views:get ID`
 
@@ -577,7 +577,7 @@ EXAMPLE
   54964c61-05d8-4f37-9638-18f7c4960c80 my-scene-view
 ```
 
-_See code: [src/commands/scene-views/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.2/src/commands/scene-views/get.ts)_
+_See code: [src/commands/scene-views/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.18.0/src/commands/scene-views/get.ts)_
 
 ## `vertex scene-views:list`
 
@@ -602,7 +602,7 @@ EXAMPLE
   a8070713-e48e-466b-b4bb-b3132895d5ce my-scene-view-2
 ```
 
-_See code: [src/commands/scene-views/list.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.2/src/commands/scene-views/list.ts)_
+_See code: [src/commands/scene-views/list.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.18.0/src/commands/scene-views/list.ts)_
 
 ## `vertex scene-views:render ID`
 
@@ -625,7 +625,7 @@ EXAMPLE
   54964c61-05d8-4f37-9638-18f7c4960c80.jpg
 ```
 
-_See code: [src/commands/scene-views/render.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.2/src/commands/scene-views/render.ts)_
+_See code: [src/commands/scene-views/render.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.18.0/src/commands/scene-views/render.ts)_
 
 ## `vertex scenes:delete [ID]`
 
@@ -647,7 +647,7 @@ EXAMPLE
   Deleting scene(s)...... done
 ```
 
-_See code: [src/commands/scenes/delete.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.2/src/commands/scenes/delete.ts)_
+_See code: [src/commands/scenes/delete.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.18.0/src/commands/scenes/delete.ts)_
 
 ## `vertex scenes:get ID`
 
@@ -669,7 +669,7 @@ EXAMPLE
   54964c61-05d8-4f37-9638-18f7c4960c80 my-scene
 ```
 
-_See code: [src/commands/scenes/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.2/src/commands/scenes/get.ts)_
+_See code: [src/commands/scenes/get.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.18.0/src/commands/scenes/get.ts)_
 
 ## `vertex scenes:list`
 
@@ -693,7 +693,7 @@ EXAMPLE
   a8070713-e48e-466b-b4bb-b3132895d5ce my-scene-2
 ```
 
-_See code: [src/commands/scenes/list.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.2/src/commands/scenes/list.ts)_
+_See code: [src/commands/scenes/list.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.18.0/src/commands/scenes/list.ts)_
 
 ## `vertex scenes:render ID`
 
@@ -717,7 +717,7 @@ EXAMPLE
   54964c61-05d8-4f37-9638-18f7c4960c80.jpg
 ```
 
-_See code: [src/commands/scenes/render.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.2/src/commands/scenes/render.ts)_
+_See code: [src/commands/scenes/render.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.18.0/src/commands/scenes/render.ts)_
 
 ## `vertex stream-keys:create`
 
@@ -739,7 +739,7 @@ EXAMPLE
   hBXAoQdnsHVhgDZkxeLEPQVxPJ600QwDMdgq
 ```
 
-_See code: [src/commands/stream-keys/create.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.2/src/commands/stream-keys/create.ts)_
+_See code: [src/commands/stream-keys/create.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.18.0/src/commands/stream-keys/create.ts)_
 
 ## `vertex webhook-subscriptions:create`
 
@@ -761,5 +761,5 @@ EXAMPLE
   ta47eOIQtg13pSyf/PgpAB47r4JYJoAZfyzAcB5x8IHo+gQ
 ```
 
-_See code: [src/commands/webhook-subscriptions/create.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.17.2/src/commands/webhook-subscriptions/create.ts)_
+_See code: [src/commands/webhook-subscriptions/create.ts](https://github.com/Vertexvis/vertex-cli/blob/v0.18.0/src/commands/webhook-subscriptions/create.ts)_
 <!-- commandsstop -->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertexvis/cli",
-  "version": "0.17.2",
+  "version": "0.18.0",
   "description": "The Vertex platform command-line interface (CLI).",
   "license": "MIT",
   "author": "Vertex Developers <support@vertexvis.com> (https://developer.vertexvis.com)",

--- a/src/commands/create-parts.ts
+++ b/src/commands/create-parts.ts
@@ -100,7 +100,7 @@ export default class CreateParts extends BaseCommand {
               verbose,
               fileName,
               filePath: srcPath,
-              indexMetadata: i.indexMetadata ?? false,
+              indexMetadata: i.indexMetadata ?? true,
               suppliedInstanceIdKey: i.suppliedInstanceIdKey,
               suppliedPartId: i.source?.suppliedPartId,
               suppliedRevisionId: i.source?.suppliedRevisionId,

--- a/test/commands/create-parts.test.ts
+++ b/test/commands/create-parts.test.ts
@@ -124,7 +124,7 @@ function createReq(
     createPartReq: (fileId) => ({
       data: {
         attributes: {
-          indexMetadata: false,
+          indexMetadata: true,
           suppliedId: item?.source?.suppliedPartId,
           suppliedInstanceIdKey: undefined,
           suppliedRevisionId: item?.source?.suppliedRevisionId,


### PR DESCRIPTION
## Summary
Part metadata will now be indexed by default for usage of the `create-parts` command. Metadata indexing can still be disabled by setting `indexMetadata: false` on the item definitions within the incoming JSON data.