### PR TITLE
[PLAT-3659] Add flag to configure poll duration and backoff

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertexvis/cli",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "The Vertex platform command-line interface (CLI).",
   "license": "MIT",
   "author": "Vertex Developers <support@vertexvis.com> (https://developer.vertexvis.com)",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1.18.9",
     "@oclif/plugin-help": "^3.3.1",
-    "@vertexvis/api-client-node": "^0.22.1",
+    "@vertexvis/api-client-node": "^0.22.2",
     "cli-ux": "^5.6.7",
     "fast-xml-parser": "^3.21",
     "fs-extra": "^10.1.0",

--- a/src/commands/create-scene.ts
+++ b/src/commands/create-scene.ts
@@ -20,6 +20,7 @@ import { SceneItem } from '../create-items/index.d';
 import BaseCommand from '../lib/base';
 import { vertexClient } from '../lib/client';
 import { fileExists } from '../lib/fs';
+import { getPollingConfiguration } from '../lib/polling';
 import { progressBar } from '../lib/progress';
 
 type CreateSceneFn = (
@@ -65,6 +66,17 @@ f79d4760-0b71-44e4-ad0b-22743fdd4ca3
         'Whether or not scene trees should be enabled for this scene.',
       default: false,
     }),
+    maxPollDuration: flags.integer({
+      char: 'm',
+      description: 'The maximum poll duration in seconds for queued jobs.',
+      default: 3600,
+    }),
+    backoff: flags.boolean({
+      char: 'b',
+      description:
+        'Whether use a backoff to the pollInterval for longer queued jobs.',
+      default: true,
+    }),
   };
 
   public async run(): Promise<void> {
@@ -83,6 +95,8 @@ f79d4760-0b71-44e4-ad0b-22743fdd4ca3
         parallelism,
         suppliedId,
         treeEnabled,
+        maxPollDuration,
+        backoff,
         validate,
         verbose,
       },
@@ -149,6 +163,10 @@ f79d4760-0b71-44e4-ad0b-22743fdd4ca3
           },
         }),
         failFast: !noFailFast,
+        polling: getPollingConfiguration({
+          maxPollDurationSeconds: maxPollDuration,
+          backoff,
+        }),
         onMsg: console.error,
         onProgress: (complete, total) => {
           if (showProgress) {

--- a/src/lib/polling.ts
+++ b/src/lib/polling.ts
@@ -1,0 +1,59 @@
+import { Polling } from '@vertexvis/api-client-node';
+import { PollIntervalMs } from '@vertexvis/api-client-node';
+
+export const DefaultBackoffMs: Record<number, number> = {
+  10: 1000,
+  40: 2000,
+  100: 5000,
+  300: 10000,
+  1000: 20000,
+};
+
+export function getPollingConfiguration({
+  maxPollDurationSeconds,
+  backoff,
+}: {
+  maxPollDurationSeconds: number;
+  backoff: boolean;
+}): Polling {
+  return {
+    intervalMs: PollIntervalMs,
+    maxAttempts: getMaxAttempts({
+      maxPollDurationSeconds,
+      backoff,
+    }),
+    backoff: backoff ? DefaultBackoffMs : undefined,
+  };
+}
+
+function getMaxAttempts({
+  maxPollDurationSeconds,
+  backoff,
+}: {
+  maxPollDurationSeconds: number;
+  backoff: boolean;
+}): number {
+  if (backoff) {
+    let remainingTimeMs = maxPollDurationSeconds * 1000;
+    let attempt = 0;
+
+    while (remainingTimeMs > 0) {
+      const backoffMs = getBackoffForAttempt(attempt + 1);
+      remainingTimeMs -= PollIntervalMs + backoffMs;
+      attempt += 1;
+    }
+
+    return attempt;
+  }
+  return Math.max(1, Math.floor(maxPollDurationSeconds / PollIntervalMs));
+}
+
+function getBackoffForAttempt(attempt: number): number {
+  const key =
+    Object.keys(DefaultBackoffMs)
+      .map((key) => parseInt(key, 10))
+      .reverse()
+      .find((key) => attempt > key) ?? 0;
+
+  return DefaultBackoffMs[key] ?? 0;
+}

--- a/src/lib/polling.ts
+++ b/src/lib/polling.ts
@@ -1,13 +1,17 @@
 import { Polling } from '@vertexvis/api-client-node';
 import { PollIntervalMs } from '@vertexvis/api-client-node';
 
-export const DefaultBackoffMs: Record<number, number> = {
+const DefaultBackoffMs: Record<number, number> = {
   10: 1000,
   40: 2000,
   100: 5000,
   300: 10000,
   1000: 20000,
 };
+
+const DefaultBackoffKeys = Object.keys(DefaultBackoffMs).map((key) =>
+  parseInt(key, 10)
+);
 
 export function getPollingConfiguration({
   maxPollDurationSeconds,
@@ -50,10 +54,7 @@ function getMaxAttempts({
 
 function getBackoffForAttempt(attempt: number): number {
   const key =
-    Object.keys(DefaultBackoffMs)
-      .map((key) => parseInt(key, 10))
-      .reverse()
-      .find((key) => attempt > key) ?? 0;
+    [...DefaultBackoffKeys].reverse().find((key) => attempt > key) ?? 0;
 
   return DefaultBackoffMs[key] ?? 0;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -669,12 +669,12 @@
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
 
-"@vertexvis/api-client-node@^0.22.1":
-  version "0.22.1"
-  resolved "https://registry.yarnpkg.com/@vertexvis/api-client-node/-/api-client-node-0.22.1.tgz#ca7a07c103513d42949f2fa807e42ba268750c06"
-  integrity sha512-yyDKEuk1Y1BaLrMOnP3N0sLDfZe6aerI12lvIJYQYdvWqPV/lXOSd4SFuoD0kVPchMJdgUQVA4A9CxDSFOhTmA==
+"@vertexvis/api-client-node@^0.22.2":
+  version "0.22.2"
+  resolved "https://registry.yarnpkg.com/@vertexvis/api-client-node/-/api-client-node-0.22.2.tgz#16776b025297135e0871ba45565d6b227ab3ed3c"
+  integrity sha512-yjhMGcvFiQpYO5aQG2WD2o5lwR4Hu0R9+h7Gh/JG2RUT0j6ZkuMjf+uyVLS1xNiry0Gfc1z6Ac1RhZiGzx1Ngw==
   dependencies:
-    axios "^1.6.0"
+    axios "^1.6.1"
     p-limit "^3"
 
 "@vertexvis/eslint-config-vertexvis-typescript@0.4":
@@ -843,7 +843,7 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
-axios@^1.6.0:
+axios@^1.6.1:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.2.tgz#de67d42c755b571d3e698df1b6504cde9b0ee9f2"
   integrity sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==


### PR DESCRIPTION
## Summary

Adds support for a `--maxPollDuration` flag to configure the amount of time to poll for for queued jobs before considering it failed, along with a `--backoff` flag to support disabling the default backoff behavior.

## Test Plan

- Using the `create-parts` and `create-scene` helpers
  - Verify the polling progressively backs off based on the defaults (+1s after 10 attempts, +2s after 40, etc)
  - Verify that providing a `--maxPollDuration` value properly limits the polling to the provided number
  - Verify that providing `--backoff=false` properly disables the backoff behavior

## Release Notes

N/A

## Possible Regressions

`create-parts` and `create-scene` helper polling behavior

## Dependencies

https://github.com/Vertexvis/vertex-api-client-node/pull/141
