### PR TITLE
[PLAT-4959] Supporting Experimental Metadata Source Keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,15 +161,16 @@ USAGE
   $ vertex create-scene [PATH]
 
 OPTIONS
-  -b, --basePath=basePath        [default: https://platform.vertexvis.com] Vertex API base path.
-  -h, --help                     show CLI help
-  -p, --parallelism=parallelism  [default: 20] Number of scene-items to create in parallel.
+  -b, --basePath=basePath             [default: https://platform.vertexvis.com] Vertex API base path.
+  -h, --help                          show CLI help
+  -p, --parallelism=parallelism       [default: 20] Number of scene-items to create in parallel.
   -v, --verbose
-  --name=name                    Name of scene.
-  --noFailFast                   Whether or not to fail the process immediately if any scene item creation fails.
-  --suppliedId=suppliedId        SuppliedId of scene.
-  --treeEnabled                  Whether or not scene trees should be enabled for this scene.
-  --validate                     Whether or not to validate the creation of every scene item.
+  --name=name                         Name of scene.
+  --noFailFast                        Whether or not to fail the process immediately if any scene item creation fails.
+  --suppliedId=suppliedId             SuppliedId of scene.
+  --treeEnabled                       Whether or not scene trees should be enabled for this scene.
+  --validate                          Whether or not to validate the creation of every scene item.
+  --experimentalSourceMetadataKeys    A list of keys to include on the scene items from the source item. Example `"Key One", "KEY_TWO"`
 
 EXAMPLE
   $ vertex create-scene --name my-scene [YOUR_PATH_TO_JSON_FILE]

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1.18.9",
     "@oclif/plugin-help": "^6.0.10",
-    "@vertexvis/api-client-node": "^0.23.0",
+    "@vertexvis/api-client-node": "^0.23.1",
     "cli-ux": "^6.0.9",
     "fast-xml-parser": "^3.21",
     "fs-extra": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertexvis/cli",
-  "version": "0.18.3",
+  "version": "0.18.4",
   "description": "The Vertex platform command-line interface (CLI).",
   "license": "MIT",
   "author": "Vertex Developers <support@vertexvis.com> (https://developer.vertexvis.com)",

--- a/src/commands/create-scene.ts
+++ b/src/commands/create-scene.ts
@@ -22,10 +22,10 @@ import { vertexClient } from '../lib/client';
 import { fileExists } from '../lib/fs';
 import { getPollingConfiguration } from '../lib/polling';
 import { progressBar } from '../lib/progress';
-
 type CreateSceneFn = (
   args: CreateSceneAndSceneItemsReq
 ) => Promise<CreateSceneAndSceneItemsRes>;
+
 export default class CreateScene extends BaseCommand {
   public static description = `Given JSON file containing SceneItems (as defined in src/create-items/index.d.ts), create scene in Vertex.`;
 
@@ -77,6 +77,10 @@ f79d4760-0b71-44e4-ad0b-22743fdd4ca3
         'Whether use a backoff to the pollInterval for longer queued jobs.',
       default: true,
     }),
+    experimentalSourceMetadataKeys: flags.string({
+      description: 'comma-separated list of items',
+      required: false,
+    }),
   };
 
   public async run(): Promise<void> {
@@ -99,8 +103,12 @@ f79d4760-0b71-44e4-ad0b-22743fdd4ca3
         backoff,
         validate,
         verbose,
+        experimentalSourceMetadataKeys,
       },
     } = this.parse(CreateScene);
+
+    const sourceMetadataKeys = experimentalSourceMetadataKeys?.split(',');
+
     const basePath = this.parsedFlags?.basePath;
     if (!(await fileExists(path))) {
       this.error(`'${path}' is not a valid file path, exiting.`);
@@ -109,6 +117,7 @@ f79d4760-0b71-44e4-ad0b-22743fdd4ca3
       this.error(`Invalid parallelism '${parallelism}'.`);
     }
 
+    console.log('sourceMetadataKeys: ', sourceMetadataKeys);
     try {
       const progress = progressBar('Creating scene');
       const client = await vertexClient(basePath, this.userConfig);
@@ -145,6 +154,7 @@ f79d4760-0b71-44e4-ad0b-22743fdd4ca3
                 ordinal: i.ordinal ?? undefined,
                 phantom: i.phantom,
                 endItem: i.endItem,
+                experimentalSourceMetadataKeys: sourceMetadataKeys,
               },
               relationships: {},
               type: 'scene-item',

--- a/src/commands/create-scene.ts
+++ b/src/commands/create-scene.ts
@@ -117,7 +117,6 @@ f79d4760-0b71-44e4-ad0b-22743fdd4ca3
       this.error(`Invalid parallelism '${parallelism}'.`);
     }
 
-    console.log('sourceMetadataKeys: ', sourceMetadataKeys);
     try {
       const progress = progressBar('Creating scene');
       const client = await vertexClient(basePath, this.userConfig);

--- a/test/commands/create-scene.test.ts
+++ b/test/commands/create-scene.test.ts
@@ -78,6 +78,7 @@ describe('create-scene', () => {
               ordinal: i.ordinal ?? undefined,
               phantom: i.phantom,
               endItem: i.endItem,
+              experimentalSourceMetadataKeys: undefined,
             },
             relationships: {},
             type: 'scene-item',

--- a/yarn.lock
+++ b/yarn.lock
@@ -721,10 +721,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
 
-"@vertexvis/api-client-node@^0.23.0":
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/@vertexvis/api-client-node/-/api-client-node-0.23.0.tgz#56be0c0641c12046fe0c2a22a4117cfba18f87fd"
-  integrity sha512-Z6/qpuZwDnBJd9KyQ7yiT0dAosAD0OKo9hcElu+l/lpP29J4OawX3KSlw0bthxD3xvNPILfZA+D1bjga3Du9ug==
+"@vertexvis/api-client-node@^0.23.1":
+  version "0.23.1"
+  resolved "https://registry.yarnpkg.com/@vertexvis/api-client-node/-/api-client-node-0.23.1.tgz#c981f4f45525456436d3569689ec8a8a02e1ac5c"
+  integrity sha512-OLk+qaWF89New+z0pr+di1qEuZbQ7Cnum8rZ/esnB95YE1n9kd7B3f0S5NgYofd8ePIS7j10mNDO1CqeUba89A==
   dependencies:
     axios "^1.6.4"
     p-limit "^3"


### PR DESCRIPTION
## Summary
<!-- Implementation and architectural changes introduced. -->

Adding a new experimental flag to create scenes with a whitelisted set of metadata.


Here is an example of how this can be used:

```
--experimentalSourceMetadataKeys KEY1,KEY_2
```

If you have keys that have a space in them, you can also wrap the entire string in quotes like this:
```
--experimentalSourceMetadataKeys "My_key,KEY_2,KEY_3,Key Four"
```
